### PR TITLE
对于无权限用户登录后跳转到/Home/NoPermission页面后，response.CharacterSet存在NPE。补充判断避免直接崩溃

### DIFF
--- a/YiSha.Util/YiSha.Util/HttpHelper.cs
+++ b/YiSha.Util/YiSha.Util/HttpHelper.cs
@@ -208,7 +208,7 @@ namespace YiSha.Util
                         }
                         else
                         {
-                            if (response.CharacterSet.ToLower().Trim() == "iso-8859-1")
+                            if (response.CharacterSet !=null && response.CharacterSet.ToLower().Trim() == "iso-8859-1")
                             {
                                 encoding = Encoding.GetEncoding("gbk");
                             }


### PR DESCRIPTION
<!-- Thank you for helping YiShaAdmin! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
