### PR TITLE
1. 升级MySqlConnector和Pomelo.EntityFrameworkCore.MySql以解决启动时报错MissingMethodException; 2. UserService.ListFilter避免param为null，避免将非表字段属性直接加入Expression。

### DIFF
--- a/YiSha.Business/YiSha.Service/OrganizationManage/UserService.cs
+++ b/YiSha.Business/YiSha.Service/OrganizationManage/UserService.cs
@@ -166,6 +166,21 @@ namespace YiSha.Service.OrganizationManage
         #region 私有方法
         private Expression<Func<UserEntity, bool>> ListFilter(UserListParam param)
         {
+            //新增/编辑部门时param为null，此时初始化默认实例以防异常
+            if (null == param)
+            {
+                param = new UserListParam();
+            }
+
+            //下面LinqExtensions.GetExpressionItems获取Expression时排除这些非表字段属性
+            var userIds = param.UserIds;
+            param.UserIds = null;
+            var startTime = param.StartTime;
+            param.StartTime = null;
+            var endTime = param.EndTime;
+            param.EndTime = null;
+            var childrenDepartmentIdList = param.ChildrenDepartmentIdList;
+            param.ChildrenDepartmentIdList = null;
 
             //var expression = LinqExtensions.True<UserEntity>();
 
@@ -175,45 +190,43 @@ namespace YiSha.Service.OrganizationManage
             }
 
             //****根据查询字段自动过滤条件****
-            var expression = LinqExtensions.GetExpressionItems<UserEntity,UserListParam>(param);
+            var expression = LinqExtensions.GetExpressionItems<UserEntity, UserListParam>(param);
 
-            if (param != null)
+            //if (!string.IsNullOrEmpty(param.UserName))
+            //{
+            //    expression = expression.And(t => t.UserName.Contains(param.UserName));
+            //}
+
+
+            if (!string.IsNullOrEmpty(userIds))
             {
-                //if (!string.IsNullOrEmpty(param.UserName))
-                //{
-                //    expression = expression.And(t => t.UserName.Contains(param.UserName));
-                //}
-
-
-                if (!string.IsNullOrEmpty(param.UserIds))
-                {
-                    long[] userIdList = TextHelper.SplitToArray<long>(param.UserIds, ',');
-                    expression = expression.And(t => userIdList.Contains(t.Id.Value));
-                }
-
-                //if (!string.IsNullOrEmpty(param.Mobile))
-                //{
-                //    expression = expression.And(t => t.Mobile.Contains(param.Mobile));
-                //}
-                //if (param.UserStatus > -1)
-                //{
-                //    expression = expression.And(t => t.UserStatus == param.UserStatus);
-                //}
-
-                if (!string.IsNullOrEmpty(param.StartTime.ParseToString()))
-                {
-                    expression = expression.And(t => t.BaseModifyTime >= param.StartTime);
-                }
-                if (!string.IsNullOrEmpty(param.EndTime.ParseToString()))
-                {
-                    param.EndTime = param.EndTime.Value.Date.Add(new TimeSpan(23, 59, 59));
-                    expression = expression.And(t => t.BaseModifyTime <= param.EndTime);
-                }
-                if (param.ChildrenDepartmentIdList != null && param.ChildrenDepartmentIdList.Count > 0)
-                {
-                    expression = expression.And(t => param.ChildrenDepartmentIdList.Contains(t.DepartmentId.Value));
-                }
+                long[] userIdList = TextHelper.SplitToArray<long>(userIds, ',');
+                expression = expression.And(t => userIdList.Contains(t.Id.Value));
             }
+
+            //if (!string.IsNullOrEmpty(param.Mobile))
+            //{
+            //    expression = expression.And(t => t.Mobile.Contains(param.Mobile));
+            //}
+            //if (param.UserStatus > -1)
+            //{
+            //    expression = expression.And(t => t.UserStatus == param.UserStatus);
+            //}
+
+            if (!string.IsNullOrEmpty(startTime.ParseToString()))
+            {
+                expression = expression.And(t => t.BaseModifyTime >= startTime);
+            }
+            if (!string.IsNullOrEmpty(endTime.ParseToString()))
+            {
+                endTime = endTime.Value.Date.Add(new TimeSpan(23, 59, 59));
+                expression = expression.And(t => t.BaseModifyTime <= endTime);
+            }
+            if (childrenDepartmentIdList != null && childrenDepartmentIdList.Count > 0)
+            {
+                expression = expression.And(t => childrenDepartmentIdList.Contains(t.DepartmentId.Value));
+            }
+
             return expression;
         }
         #endregion

--- a/YiSha.Data/YiSha.Data.EF/DbContextExtension.cs
+++ b/YiSha.Data/YiSha.Data.EF/DbContextExtension.cs
@@ -110,40 +110,40 @@ namespace YiSha.Data.EF
                                 prop.SetValue(entry.Entity, false);
                                 break;
                             case "Char":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, '\0');
                                 break;
                             case "SByte":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, (sbyte)0);
                                 break;
                             case "Byte":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, (byte)0);
                                 break;
                             case "Int16":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, (short)0);
                                 break;
                             case "UInt16":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, (ushort)0);
                                 break;
                             case "Int32":
                                 prop.SetValue(entry.Entity, 0);
                                 break;
                             case "UInt32":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, 0U);
                                 break;
                             case "Int64":
-                                prop.SetValue(entry.Entity, (Int64)0);
+                                prop.SetValue(entry.Entity, 0L);
                                 break;
                             case "UInt64":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, 0LU);
                                 break;
                             case "Single":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, 0F);
                                 break;
                             case "Double":
-                                prop.SetValue(entry.Entity, 0);
+                                prop.SetValue(entry.Entity, 0D);
                                 break;
                             case "Decimal":
-                                prop.SetValue(entry.Entity, (decimal)0);
+                                prop.SetValue(entry.Entity, 0M);
                                 break;
                             case "DateTime":
                                 prop.SetValue(entry.Entity, GlobalConstant.DefaultTime);

--- a/YiSha.Data/YiSha.Data.EF/YiSha.Data.EF.csproj
+++ b/YiSha.Data/YiSha.Data.EF/YiSha.Data.EF.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.120" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/YiSha.Data/YiSha.Data/YiSha.Data.csproj
+++ b/YiSha.Data/YiSha.Data/YiSha.Data.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
-    <PackageReference Include="MySqlConnector" Version="2.3.1" />
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.120" />
   </ItemGroup>
 


### PR DESCRIPTION
1. 升级MySqlConnector和Pomelo.EntityFrameworkCore.MySql以解决启动时报错MissingMethodException (Method not found: Void CoreTypeMappingParameters…ctor);
3. UserService.ListFilter避免param为null，避免将非表字段属性直接加入Expression。